### PR TITLE
feat: cloud run tf and manage tfstate with gcs

### DIFF
--- a/terraform/modules/backend/cloud_run.tf
+++ b/terraform/modules/backend/cloud_run.tf
@@ -1,0 +1,24 @@
+resource "google_cloud_run_v2_service" "line-bot" {
+  project  = var.project_id
+  name     = "linebot-googlecloud-sample"
+  location = var.region
+
+  template {
+    containers {
+      # TODO: CloudBuild で指定した image に変更する
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/cloud-run-source-deploy/linebot-dev:latest"
+    }
+
+    scaling {
+      min_instance_count = var.cloud_run_min_instance_count
+      max_instance_count = var.cloud_run_max_instance_count
+    }
+    service_account = google_service_account.line_bot_cloud_run.email
+  }
+}
+
+resource "google_service_account" "line_bot_cloud_run" {
+  account_id   = "line-bot-cloud-run"
+  display_name = "Line Bot Cloud Run Service Account"
+  project      = var.project_id
+}

--- a/terraform/modules/backend/main.tf
+++ b/terraform/modules/backend/main.tf
@@ -1,1 +1,0 @@
-resource "null_resource" "dummy" {}

--- a/terraform/modules/backend/variable.tf
+++ b/terraform/modules/backend/variable.tf
@@ -2,7 +2,7 @@ variable "project_id" {
   type = string
 }
 variable "region" {
-    type = string
+  type = string
 }
 variable "cloud_run_min_instance_count" {
   type = number

--- a/terraform/modules/backend/variable.tf
+++ b/terraform/modules/backend/variable.tf
@@ -1,0 +1,12 @@
+variable "project_id" {
+  type = string
+}
+variable "region" {
+    type = string
+}
+variable "cloud_run_min_instance_count" {
+  type = number
+}
+variable "cloud_run_max_instance_count" {
+  type = number
+}

--- a/terraform/resources/backend/backend.tf
+++ b/terraform/resources/backend/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "linedc-handson-terraform-state" // your gcs bucket name
+    prefix = "backend"                        // your gcs prefix
+  }
+}

--- a/terraform/resources/backend/main.tf
+++ b/terraform/resources/backend/main.tf
@@ -1,7 +1,7 @@
 module "backend" {
-  source         = "../../modules/backend"
-  project_id     = var.project_id
-  region         = var.region
+  source     = "../../modules/backend"
+  project_id = var.project_id
+  region     = var.region
 
   cloud_run_min_instance_count = 1
   cloud_run_max_instance_count = 1

--- a/terraform/resources/backend/main.tf
+++ b/terraform/resources/backend/main.tf
@@ -1,1 +1,10 @@
-resource "null_resource" "dummy" {}
+module "backend" {
+  source         = "../../modules/backend"
+  project_id     = var.project_id
+  region         = var.region
+
+  cloud_run_min_instance_count = 1
+  cloud_run_max_instance_count = 1
+
+}
+

--- a/terraform/resources/backend/provider.tf
+++ b/terraform/resources/backend/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/terraform/resources/backend/variable.tf
+++ b/terraform/resources/backend/variable.tf
@@ -1,0 +1,6 @@
+variable "project_id" {
+  default = "linedc-handson"
+}
+variable "region" {
+  default = "asia-northeast1"
+}

--- a/terraform/resources/setup/backend.tf
+++ b/terraform/resources/setup/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "linedc-handson-terraform-state" // your gcs bucket name
+    prefix = "setup"                          // your gcs prefix
+  }
+}

--- a/terraform/resources/setup/main.tf
+++ b/terraform/resources/setup/main.tf
@@ -1,0 +1,8 @@
+resource "google_storage_bucket" "terraform_state" {
+  name     = "linedc-handson-terraform-state" // your gcs bucket name
+  location = "ASIA"
+  versioning {
+    enabled = true
+  }
+}
+

--- a/terraform/resources/setup/provider.tf
+++ b/terraform/resources/setup/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/terraform/resources/setup/variable.tf
+++ b/terraform/resources/setup/variable.tf
@@ -1,0 +1,6 @@
+variable "project_id" {
+  default = "linedc-handson"
+}
+variable "region" {
+  default = "asia-northeast1"
+}


### PR DESCRIPTION
## 関連 Issus or Ticket

https://www.notion.so/Terraform-Cloud-Run-e3cacb8d340142c6af12cbbbb8141842

## 変更点

- cloud run の tf を追加
- tfstate を管理する bucket を 追加
- それぞれ bucket に prefix で管理

## 確認して欲しいこと

- tf 経由でデプロイ
  - 一旦 apply しただけなので、環境変数などは消えてしまってます🙏（以降 CloudBuild 経由でしかデプロイしないと思うので、適当にしちゃいました）

<img width="1369" alt="image" src="https://github.com/tokku5552/linebot-googlecloud-sample/assets/63399296/15c79ed3-db82-44d8-9a48-f2abb670fb3e">

- gcs

<img width="1263" alt="image" src="https://github.com/tokku5552/linebot-googlecloud-sample/assets/63399296/832b72cf-b582-4cfb-b2d9-4d9fba35fef8">